### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_documents/api.py
+++ b/invenio_documents/api.py
@@ -22,7 +22,7 @@
 Following example shows how to handle documents metadata::
 
     >>> from flask import g
-    >>> from invenio.base.factory import create_app
+    >>> from invenio_base.factory import create_app
     >>> app = create_app()
     >>> ctx = app.test_request_context()
     >>> ctx.push()
@@ -48,7 +48,7 @@ from flask import current_app
 from fs.opener import opener
 from jsonschema import validate
 
-from invenio.base.utils import toposort_send
+from invenio_base.utils import toposort_send
 from invenio.ext.sqlalchemy import db
 from invenio.utils.datastructures import SmartDict
 
@@ -101,7 +101,7 @@ class Document(SmartDict):
         Find existing document::
 
             >>> from flask import g
-            >>> from invenio.base.factory import create_app
+            >>> from invenio_base.factory import create_app
             >>> app = create_app()
             >>> ctx = app.test_request_context()
             >>> ctx.push()

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'fs>=0.4',
+    'invenio-base>=0.1.0',
     # FIXME 'Invenio>=2.1',
 ]
 
@@ -51,6 +52,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
- FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
