### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -30,8 +30,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Documents.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-documents
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ directory = invenio_documents/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_documents/translations/messages.pot
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
     keywords='invenio documents',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-documents',
     packages=packages,
     zip_safe=False,


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
